### PR TITLE
Upgrade compromise@11.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "fix": "eslint . --fix"
   },
   "dependencies": {
-    "compromise": "11.2.2",
+    "compromise": "11.2.3",
     "probot": "4.1.0"
   },
   "devDependencies": {

--- a/validate-title.js
+++ b/validate-title.js
@@ -31,24 +31,8 @@ function validateFirstTerm(parsed) {
 }
 
 // The following verbs starting with `re` are categorized as singular nouns
-// See: https://github.com/nlp-compromise/compromise/issues/412
-const nounWhitelist = new Set([
-  'configure',
-  'expose',
-  'implement',
-  'introduce',
-  'pin',
-  'rebuild',
-  'reconcile',
-  'record',
-  'recover',
-  'redefine',
-  'repeat',
-  'reset',
-  'resolve',
-  'restructure',
-  'upgrade',
-]);
+// See: https://github.com/nlp-compromise/compromise/issues/448
+const nounWhitelist = new Set(['configure', 'implement', 'pin', 'reset']);
 
 function isSingleSentence(sentences) {
   return sentences.length === 1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,9 +630,9 @@ commander@^2.11.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
-compromise@11.2.2:
-  version "11.2.2"
-  resolved "https://registry.yarnpkg.com/compromise/-/compromise-11.2.2.tgz#705d8ff78637e69d5a2791cbbca0a67684158b6a"
+compromise@11.2.3:
+  version "11.2.3"
+  resolved "https://registry.yarnpkg.com/compromise/-/compromise-11.2.3.tgz#5f2b33fdd4188e47f3a9a551e732a14a865d85d0"
   dependencies:
     efrt-unpack "2.0.3"
 


### PR DESCRIPTION
Upgrade compromise for verb fixes. Keeping these verbs in the unit test for now so we have some form of sanity checking if we decide to move to another library.