### PR TITLE
Add "clean", "restore", and "preserve" to noun whitelist

### DIFF
--- a/__tests__/validate-title.js
+++ b/__tests__/validate-title.js
@@ -48,6 +48,7 @@ test('valid commits pass', () => {
     'Log some arbitrary thing',
     'Track some arbitrary thing',
     'Run some arbitrary thing',
+    'Clean up some arbitrary thing',
   ];
 
   valid.forEach(msg => {

--- a/__tests__/validate-title.js
+++ b/__tests__/validate-title.js
@@ -49,6 +49,8 @@ test('valid commits pass', () => {
     'Track some arbitrary thing',
     'Run some arbitrary thing',
     'Clean up some arbitrary thing',
+    'Restore some arbitrary thing',
+    'Preserve some arbitrary thing',
   ];
 
   valid.forEach(msg => {

--- a/validate-title.js
+++ b/validate-title.js
@@ -44,6 +44,7 @@ const nounWhitelist = new Set([
   'set',
   'track',
   'run',
+  'clean',
 ]);
 
 function isSingleSentence(sentences) {

--- a/validate-title.js
+++ b/validate-title.js
@@ -45,6 +45,8 @@ const nounWhitelist = new Set([
   'track',
   'run',
   'clean',
+  'restore',
+  'preserve',
 ]);
 
 function isSingleSentence(sentences) {


### PR DESCRIPTION
Title erroneously failed validation here: https://github.com/fusionjs/fusion-plugin-rpc-redux-react/pull/132 and https://github.com/fusionjs/fusion-react/pull/172