### PR TITLE
Add 'instrument' to imperative verb whitelist

### DIFF
--- a/validate-title.js
+++ b/validate-title.js
@@ -49,6 +49,7 @@ const nounWhitelist = new Set([
   'restore',
   'preserve',
   'omit',
+  'instrument',
 ]);
 
 function isSingleSentence(sentences) {


### PR DESCRIPTION
Fixes issue from: https://github.com/fusionjs/fusion-cli/pull/769